### PR TITLE
allow for optional not creating pvc in galaxy deployment

### DIFF
--- a/galaxy-simple/templates/galaxy_pvc.yaml
+++ b/galaxy-simple/templates/galaxy_pvc.yaml
@@ -9,3 +9,4 @@ spec:
   resources:
     requests:
       storage: {{.Values.galaxy_pvc_capacity}} 
+{{ end }}

--- a/galaxy-simple/templates/galaxy_pvc.yaml
+++ b/galaxy-simple/templates/galaxy_pvc.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.galaxy_create_pvc }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/galaxy-simple/values.yaml
+++ b/galaxy-simple/values.yaml
@@ -39,6 +39,7 @@ galaxy_node_port_exposed: 30700
 domain: "mydomain.dev" 
 
 # Storage request
+galaxy_create_pvc: true
 galaxy_pvc_capacity: "15Gi"
 #postgres:
 #        postgres_pvc: "postgres-pvc"


### PR DESCRIPTION
It is not tested yet - but it looks ok or what do you think?